### PR TITLE
Fixed deprecation warning before Lita 5.0 comes out

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 PATH
   remote: .
   specs:
-    lita-giphy (1.0.1)
-      lita (~> 3.0)
+    lita-giphy (1.0.2)
+      lita (>= 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    faraday (0.9.0)
+    faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     http_router (0.11.1)
       rack (>= 1.0.0)
       url_mount (~> 0.2.1)
-    i18n (0.6.9)
-    ice_nine (0.11.0)
-    lita (3.0.2)
+    i18n (0.7.0)
+    ice_nine (0.11.1)
+    lita (4.3.2)
       bundler (>= 1.3)
       faraday (>= 0.8.7)
       http_router (>= 0.11.1)
@@ -24,17 +24,19 @@ GEM
       multi_json (>= 1.7.7)
       puma (>= 2.7.1)
       rack (>= 1.5.2)
+      rb-readline (>= 0.5.1)
       redis-namespace (>= 1.3.0)
       thor (>= 0.18.1)
-    multi_json (1.8.4)
+    multi_json (1.11.0)
     multipart-post (2.0.0)
-    puma (2.7.1)
+    puma (2.11.2)
       rack (>= 1.1, < 2.0)
-    rack (1.5.2)
+    rack (1.6.0)
     rake (10.1.0)
-    redis (3.0.7)
-    redis-namespace (1.4.1)
-      redis (~> 3.0.4)
+    rb-readline (0.5.2)
+    redis (3.2.1)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     rspec (3.0.0.beta2)
       rspec-core (= 3.0.0.beta2)
       rspec-expectations (= 3.0.0.beta2)
@@ -47,7 +49,7 @@ GEM
     rspec-mocks (3.0.0.beta2)
       rspec-support (= 3.0.0.beta2)
     rspec-support (3.0.0.beta2)
-    thor (0.18.1)
+    thor (0.19.1)
     url_mount (0.2.1)
       rack
 

--- a/lib/lita/handlers/giphy.rb
+++ b/lib/lita/handlers/giphy.rb
@@ -8,9 +8,7 @@ module Lita
         "giphy QUERY" => "Grabs a gif tagged with QUERY."
       })
 
-      def self.default_config(config)
-        config.api_key = nil
-      end
+      config :api_key, require: true, type: String
 
       def giphy(response)
         return unless validate(response)

--- a/lib/lita/handlers/giphy.rb
+++ b/lib/lita/handlers/giphy.rb
@@ -8,7 +8,7 @@ module Lita
         "giphy QUERY" => "Grabs a gif tagged with QUERY."
       })
 
-      config :api_key, require: true, type: String
+      config :api_key, required: true, type: String
 
       def giphy(response)
         return unless validate(response)

--- a/spec/lita/handlers/giphy_spec.rb
+++ b/spec/lita/handlers/giphy_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe Lita::Handlers::Giphy, lita_handler: true do
-  it { routes_command("giphy swanson dance").to :giphy }
-  it { routes_command("gif swanson dance").to :giphy }
-  it { routes_command("animate swanson dance").to :giphy }
+  it { is_expected.to route_command("giphy swanson dance").to(:giphy) }
+  it { is_expected.to route_command("gif swanson dance").to(:giphy) }
+  it { is_expected.to route_command("animate swanson dance").to(:giphy) }
 
   it "sets the Giphy API key to nil by default" do
     expect(Lita.config.handlers.giphy.api_key).to be_nil
@@ -28,9 +28,9 @@ describe Lita::Handlers::Giphy, lita_handler: true do
     "bitly_gif_url":"http:\/\/gph.is\/18Abg9K", "bitly_fullscreen_url":"http:\/\/gph.is\/18AbeyG", "bitly_tiled_url":"http:\/\/gph.is\/17vT1VT", "embed_url":"http:\/\/giphy.com\/embed\/11nMit55uRGIuc", "images":
       {
         "fixed_height":
-          {"url":"http:\/\/media0.giphy.com\/media\/11nMit55uRGIuc\/200.gif", "width":"355", "height":"200"}, 
+          {"url":"http:\/\/media0.giphy.com\/media\/11nMit55uRGIuc\/200.gif", "width":"355", "height":"200"},
         "fixed_height_still":
-          {"url":"http:\/\/media1.giphy.com\/media\/11nMit55uRGIuc\/200_s.gif","width":"355","height":"200"}, 
+          {"url":"http:\/\/media1.giphy.com\/media\/11nMit55uRGIuc\/200_s.gif","width":"355","height":"200"},
         "fixed_height_downsampled":
           {"url":"http:\/\/media0.giphy.com\/media\/11nMit55uRGIuc\/200_d.gif","width":"355","height":"200"},
         "fixed_width":
@@ -39,7 +39,7 @@ describe Lita::Handlers::Giphy, lita_handler: true do
           {"url":"http:\/\/media2.giphy.com\/media\/11nMit55uRGIuc\/200w_s.gif","width":"200","height":"113"},
         "fixed_width_downsampled":
           {"url":"http:\/\/media0.giphy.com\/media\/11nMit55uRGIuc\/200w_d.gif","width":"200","height":"113"},
-        "original": 
+        "original":
           {"url":"http:\/\/media3.giphy.com\/media\/11nMit55uRGIuc\/giphy.gif", "width":"500", "height":"282", "size":"507637","frames":"20"}
       }
     }
@@ -51,7 +51,7 @@ describe Lita::Handlers::Giphy, lita_handler: true do
   }
           BODY
         end
-        
+
         let(:response) { double("Faraday::Response", status: 200, body: body) }
 
         before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
 require 'lita-giphy'
 require 'lita/rspec'
+
+Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
Fixed deprecation warnings for global_config

``` log
[2015-05-01 02:50:26 UTC] WARN: Lita::Handler.default_config is deprecated and will be removed in Lita 5.0. Use Lita::Handler.config instead. The method was found defined in the giphy handler.
```

Also addressed some deprecation warnings in specs
